### PR TITLE
Fixed overflowing input text on high-res small screens (and clearer login text)

### DIFF
--- a/kde/sddm/Login.qml
+++ b/kde/sddm/Login.qml
@@ -111,7 +111,7 @@ SessionManagementScreen {
         contentItem: Text {
             text: loginButton.text
             font: loginButton.font
-            opacity: enabled ? 1.0 : 0.3
+            opacity: enabled ? 1.0 : 0.8
             color: "#ffffff"
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter

--- a/kde/sddm/Login.qml
+++ b/kde/sddm/Login.qml
@@ -120,8 +120,8 @@ SessionManagementScreen {
 
         background: Rectangle {
             id: buttonBackground
-            width:30
-            height: 270
+            height: parent.width
+            width: height / 9
             radius: width / 2
                 rotation: -90
                 anchors.centerIn: parent

--- a/kde/sddm/components/Input.qml
+++ b/kde/sddm/components/Input.qml
@@ -12,8 +12,8 @@ TextField {
         color: "#1E2326"
         opacity: 0.7
         radius: parent.width / 2
-        height: 30
-        width: 270
+        width: parent.width
+        height: width / 9
         border.width: 1
         border.color: "#121517"
         anchors.centerIn: parent


### PR DESCRIPTION
Having a disabled login button with almost transparent text makes it hard to read, thus not as aesthetic as a clearer label. IMHO transparent text is not that good an indicator that the button is unclickable. Besides, everyone knows that they have to enter a password before they log in, as is evident by the password input, and by the fact that they created a password.