### PR TITLE
Fix parsing errors for invalid numbers

### DIFF
--- a/gtk-3.0/apps/_pantheon.scss
+++ b/gtk-3.0/apps/_pantheon.scss
@@ -360,9 +360,9 @@ radiobutton.color-button {
       box-shadow: inset-shadow();
       color: $base_color;
       -gtk-icon-source: -gtk-icontheme("check-active-symbolic");
-      min-height: rem(12px);
-      min-width: rem(12px);
-      padding: rem(3px);
+      min-height: 12px;
+      min-width: 12px;
+      padding: 3px;
   }
 
   &.red check,

--- a/gtk-3.0/gtk-dark.css
+++ b/gtk-3.0/gtk-dark.css
@@ -5850,9 +5850,9 @@ radiobutton.color-button:active > radio {
   box-shadow: inset-shadow();
   color: #181b28;
   -gtk-icon-source: -gtk-icontheme("check-active-symbolic");
-  min-height: rem(12px);
-  min-width: rem(12px);
-  padding: rem(3px); }
+  min-height: 12px;
+  min-width: 12px;
+  padding: 3px; }
 .color-button.red check, .color-button.red radio, .color-button.strawberry check, .color-button.strawberry radio {
   background-color: @STRAWBERRY_300;
   -gtk-icon-shadow: 0 1px 1px @STRAWBERRY_500; }

--- a/gtk-3.0/gtk.css
+++ b/gtk-3.0/gtk.css
@@ -5874,9 +5874,9 @@ radiobutton.color-button:active > radio {
   box-shadow: inset-shadow();
   color: #ebf0f5;
   -gtk-icon-source: -gtk-icontheme("check-active-symbolic");
-  min-height: rem(12px);
-  min-width: rem(12px);
-  padding: rem(3px); }
+  min-height: 12px;
+  min-width: 12px;
+  padding: 3px; }
 .color-button.red check, .color-button.red radio, .color-button.strawberry check, .color-button.strawberry radio {
   background-color: @STRAWBERRY_300;
   -gtk-icon-shadow: 0 1px 1px @STRAWBERRY_500; }


### PR DESCRIPTION
I get 4 GTK parsing errors when using this theme (on Garuda Linux). Three are caused by these rem(n px); that should just be pixel values I believe, looking at the surrounding code.

The last parsing error is with the `inset-shadow()` function thing (idk, I don't do scss) which is trying to be interpreted as a subtraction and just in general doesn't work. I'm less sure about how to fix that issue. You can see my `master` branch for what I did to try to fix it but I honestly have no idea how to test to see what that changed, so I might have made something ugly. Hopefully someone more familiar with the theme can take a look.