### PR TITLE
Update Sweet.colorscheme to Color0 hard to be seen.

### DIFF
--- a/kde/konsole/Sweet.colorscheme
+++ b/kde/konsole/Sweet.colorscheme
@@ -8,13 +8,13 @@ Color=40,44,52
 Color=40,44,52
 
 [Color0]
-Color=85,85,255
+Color=105,115,136
 
 [Color0Faint]
-Color=85,85,255
+Color=105,115,136
 
 [Color0Intense]
-Color=85,85,255
+Color=105,115,136
 
 [Color1]
 Color=237,37,78

--- a/kde/konsole/Sweet.colorscheme
+++ b/kde/konsole/Sweet.colorscheme
@@ -8,13 +8,13 @@ Color=40,44,52
 Color=40,44,52
 
 [Color0]
-Color=40,44,52
+Color=85,85,255
 
 [Color0Faint]
-Color=40,44,52
+Color=85,85,255
 
 [Color0Intense]
-Color=40,44,52
+Color=85,85,255
 
 [Color1]
 Color=237,37,78


### PR DESCRIPTION
Color0 is hard to be seen with Konsole's background color. This proposes a different color which makes it easier to differentiate between the 2 colors.

CURRENT `COLOR0` 40,44,52

![193f7f9bed650ed431db8e7afe32d282fcfb8481_2_1035x580](https://github.com/EliverLara/Sweet/assets/35015576/5f88a3c7-a228-48d6-a084-c57841469c87)

![image](https://github.com/EliverLara/Sweet/assets/35015576/088f7ae8-ed5d-4d85-8682-54c68c257402)

![image](https://github.com/EliverLara/Sweet/assets/35015576/a38346b1-101f-49fd-aabc-b43491dc3102)







PROPOSED `COLOR0` 85,85,255

![image](https://github.com/EliverLara/Sweet/assets/35015576/5cefdd1d-c664-4f4a-92d3-39a0f4fcec75)

![image](https://github.com/EliverLara/Sweet/assets/35015576/99b612da-264e-4b61-895d-9e2d0efde871)
