### PR TITLE
[Mars] Fix OSD volume bar when volume amplification is on

### DIFF
--- a/kde/plasma/look-and-feel/Sweet-Mars/contents/osd/Osd.qml
+++ b/kde/plasma/look-and-feel/Sweet-Mars/contents/osd/Osd.qml
@@ -37,6 +37,8 @@ PlasmaCore.Dialog {
     // Set to true if the value is meant for progress bar,
     // false for displaying the value as normal text
     property bool showingProgress: false
+    // Maximum value of progress bar (overriden for volume amplification)
+    property int osdMaxValue: 100
 
     mainItem: OsdItem {
         rootItem: root

--- a/kde/plasma/look-and-feel/Sweet-Mars/contents/osd/OsdItem.qml
+++ b/kde/plasma/look-and-feel/Sweet-Mars/contents/osd/OsdItem.qml
@@ -61,7 +61,7 @@ Item {
 
         visible: rootItem.showingProgress
         minimumValue: 0
-        maximumValue: 100
+        maximumValue: rootItem.osdMaxValue
 
         value: Number(rootItem.osdValue)
     }


### PR DESCRIPTION
- Fixed an issue that involves OSD volume and brightness bars breaking when volume amplification is enabled and the volume is pushed over 100%
- Added missing osdMaxValue peoperty to support volume >100%
- Replaced hardcoded maximumValue with dynamic osdMaxValue