### PR TITLE
[Mars] OSD percentages

### DIFF
--- a/kde/plasma/look-and-feel/Sweet-Mars/contents/osd/Osd.qml
+++ b/kde/plasma/look-and-feel/Sweet-Mars/contents/osd/Osd.qml
@@ -37,6 +37,8 @@ PlasmaCore.Dialog {
     // Set to true if the value is meant for progress bar,
     // false for displaying the value as normal text
     property bool showingProgress: false
+    // Maximum value of progress bar (overriden for volume amplification)
+    property int osdMaxValue: 100
 
     mainItem: OsdItem {
         rootItem: root

--- a/kde/plasma/look-and-feel/Sweet-Mars/contents/osd/OsdItem.qml
+++ b/kde/plasma/look-and-feel/Sweet-Mars/contents/osd/OsdItem.qml
@@ -35,6 +35,8 @@ Item {
     //  | |                | |
     //  | \----------------/ |
     //  |      spacing       |
+    //  |     percentage     |
+    //  |      spacing       |
     //  | [progressbar/text] |
     //  |      spacing       |
     //  \--------------------/
@@ -64,7 +66,27 @@ Item {
         maximumValue: rootItem.osdMaxValue
 
         value: Number(rootItem.osdValue)
+
+        PlasmaExtra.Heading {
+            anchors {
+                bottom: progressBar.top
+                bottomMargin: units.smallSpacing
+                horizontalCenter: parent.horizontalCenter
+            }
+            level: 4
+            text: Math.round(progressBar.value) + "%"
+            color: {
+                if (progressBar.value <= 100) {
+                    return theme.textColor
+                } else if (progressBar.value <= 125) {
+                    return theme.neutralTextColor
+                } else {
+                    return theme.negativeTextColor
+                }
+            }
+        }
     }
+
     PlasmaExtra.Heading {
         id: label
         anchors {
@@ -73,7 +95,6 @@ Item {
             right: parent.right
             margins: Math.floor(units.smallSpacing / 2)
         }
-
         visible: !rootItem.showingProgress
         text: rootItem.showingProgress ? "" : (rootItem.osdValue ? rootItem.osdValue : "")
         horizontalAlignment: Text.AlignHCenter

--- a/kde/plasma/look-and-feel/Sweet-Mars/contents/osd/OsdItem.qml
+++ b/kde/plasma/look-and-feel/Sweet-Mars/contents/osd/OsdItem.qml
@@ -61,7 +61,7 @@ Item {
 
         visible: rootItem.showingProgress
         minimumValue: 0
-        maximumValue: 100
+        maximumValue: rootItem.osdMaxValue
 
         value: Number(rootItem.osdValue)
     }


### PR DESCRIPTION
- Adds numeric percentages on top of volume/brightness bars in Mars OSD
- Sound volume percentages from 101% to 125% are displayed in orange, 126% to 150% in red (as the quality of sound decreases with sound amplification)